### PR TITLE
fix(ios-action-bar): Fix for #5743; navController may be null

### DIFF
--- a/tns-core-modules/ui/action-bar/action-bar.ios.ts
+++ b/tns-core-modules/ui/action-bar/action-bar.ios.ts
@@ -129,7 +129,7 @@ export class ActionBar extends ActionBarBase {
         }
 
         // Find previous ViewController in the navigation stack
-        const indexOfViewController = navController.viewControllers.indexOfObject(viewController);
+        const indexOfViewController = navController ? navController.viewControllers.indexOfObject(viewController) : null;
         if (indexOfViewController > 0 && indexOfViewController < navController.viewControllers.count) {
             previousController = navController.viewControllers[indexOfViewController - 1];
         }


### PR DESCRIPTION
From my own Crashlytics:
`stderr: file:///app/vendor.js:1:860568: JS ERROR TypeError: null is not an object (evaluating 'a.viewControllers')`
```
file:///app/vendor.js:1:860489
var l,p=a.viewControllers.indexOfObject(n);if(p>0&&p<a.viewControllers.count&&(t=a.viewControllers[p-1]),t)
```
which corresponds to:
https://github.com/NativeScript/NativeScript/blob/2fc1d8a8d4cf64e98eb98296e21564ac9b508f95/tns-core-modules/ui/action-bar/action-bar.ios.ts#L132

further up `navController` is checked for truthiness:
https://github.com/NativeScript/NativeScript/blob/2fc1d8a8d4cf64e98eb98296e21564ac9b508f95/tns-core-modules/ui/action-bar/action-bar.ios.ts#L119

So applying same logic.

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/NativeScript/blob/master/DevelopmentWorkflow.md#running-unit-tests.
- [ ] Tests for the changes are included - https://github.com/NativeScript/NativeScript/blob/master/WritingUnitTests.md.